### PR TITLE
Feature#17 同じユーザーからのリアクション重複を防ぐ。

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,12 +167,8 @@ def add_message():
 
     if message:
         dbConnect.createMessage(uid, channel_id, message)
-
-    channel = dbConnect.getChannelById(channel_id)
-    messages = dbConnect.getMessageAll(channel_id)
-    reactions = dbConnect.getReactionAll(channel_id)
-    
-    return render_template('detail.html', messages=messages, channel=channel, uid=uid, reactions=reactions)
+ 
+    return redirect(url_for('result', channel_id=channel_id))
 
 @app.route('/reaction', methods=['POST'])
 def reaction():
@@ -183,15 +179,11 @@ def reaction():
     mid = request.form.get('message_id')
     reaction_code = request.form.get('reaction_code')
     channel_id =request.form.get('channel_id')
-    
-    if mid:
+    try:
         dbConnect.addReaction(mid, uid, reaction_code)
-
-    channel = dbConnect.getChannelById(channel_id)
-    messages = dbConnect.getMessageAll(channel_id)
-    reactions = dbConnect.getReactionAll(channel_id)
-
-    return render_template('detail.html', messages=messages, channel=channel, uid=uid, reactions=reactions)
+        return redirect(url_for('result', channel_id=channel_id))
+    except:
+        return redirect(url_for('result', channel_id=channel_id))
 
 
 
@@ -212,6 +204,17 @@ def delete_message():
     
     return render_template('detail.html', messages=messages, channel=channel, uid=uid, reactions=reactions)
 
+@app.route('/result/<channel_id>')
+def result(channel_id):
+    uid = session.get("uid")
+    if uid is None:
+        return redirect('/login')
+    
+    channel = dbConnect.getChannelById(channel_id)
+    messages = dbConnect.getMessageAll(channel_id)
+    reactions = dbConnect.getReactionAll(channel_id)
+
+    return render_template('detail.html', messages=messages, channel=channel, uid=uid, reactions=reactions)
 
 @app.errorhandler(404)
 def show_error404(error):

--- a/init.sql
+++ b/init.sql
@@ -38,10 +38,11 @@ CREATE TABLE T_MESSAGE (
 );
 
 CREATE TABLE T_REACTION (
-    id serial PRIMARY KEY,
+    id serial,
     mid integer REFERENCES T_MESSAGE(id) ON DELETE CASCADE,
     uid varchar(255) REFERENCES M_USER(id),
-    reaction_code varchar(255)
+    reaction_code varchar(255),
+    PRIMARY KEY (mid, uid, reaction_code)
 );
 
 CREATE TABLE M_REACTION (

--- a/models.py
+++ b/models.py
@@ -1,6 +1,7 @@
 import pymysql
 import datetime
 from util.DB import DB
+from psycopg2 import IntegrityError
 
 class dbConnect:
     def createUser(user):
@@ -182,6 +183,9 @@ class dbConnect:
             sql = "INSERT INTO T_REACTION(mid, uid, reaction_code) VALUES(%s, %s, %s)"
             cur.execute(sql, (mid, uid, reaction_code))
             conn.commit()
+        except IntegrityError as e:
+            print(e + '一意制約違反')
+            return None
         except Exception as e:
             print(e + 'が発生しています')
             return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ shellescape==3.8.1
 SQLAlchemy==1.4.41
 urllib3==1.26.12
 Werkzeug==2.2.2
+psycopg2-binary==2.9.6

--- a/static/css/detail.css
+++ b/static/css/detail.css
@@ -55,23 +55,23 @@
 }
 
 .my-user-name {
-  font-size: 8px;
+  font-size: 12px;
   color: var(--wood);
   margin-left: auto;
   margin-right: 20px;
 }
 .my-send-time {
-  font-size: 8px;
+  font-size: 10px;
   color: var(--wood);
   margin-left: auto;
   margin-right: 20px;
 }
 .user-name {
-  font-size: 8px;
+  font-size: 12px;
   color: var(--wood);
 }
 .send-time {
-  font-size: 8px;
+  font-size: 10px;
   color: var(--wood);
 }
 
@@ -89,6 +89,15 @@
   background-color: var(--carbon);
   height: 40px;
   width: 40px;
+  line-height: 47px;
+  padding: 0;
+  margin: 0;
+  bottom: 8px;
+  right: 8px;
+}
+.reaction-btn {
+  height: 40px;
+  width: 25px;
   line-height: 47px;
   padding: 0;
   margin: 0;
@@ -211,10 +220,52 @@
   left: 20px;
 }
 
-#other-message-reactions{
-  width: 30px;
-  flex-direction: row;
+.other-message-reactions{
+  display: flex;
+  margin-left: 55px;
 }
+
+.other-message-reactions img{
+  width: 27px;
+  height: auto;
+}
+.reaction-box {
+  display: flex;
+  align-items: center;
+  background-color: rgb(221, 217, 217);
+  border-radius: 4px;
+  padding: 3px;
+  margin-bottom: 5px;
+  margin-right: 5px;
+}
+
+.reaction-count {
+  font-family: Arial;
+  color: gray;
+  margin-right: 1px;
+  font-size: 20px;
+}
+
+.my-message-reactions{
+  display: flex;
+  justify-content: flex-end;
+  margin-right: 75px;
+}
+
+.my-message-reactions img{
+  width: 27px;
+  height: auto;
+}
+
+.specific-div-other {
+  margin-top: -35px;
+  margin-bottom: 0px; /* 特定のdivに適用するスタイルルール */
+}
+.specific-div-my {
+  margin-top: -23px;
+  margin-bottom: 0px; /* 特定のdivに適用するスタイルルール */
+}
+
 
 @media screen and (max-width: 550px) {
   #chatroom-description {

--- a/templates/detail.html
+++ b/templates/detail.html
@@ -40,8 +40,17 @@
                   </form>
                 </div>
                 <p class="my-send-time">{{ message.send_at }}</p>
-                <div>
-                  <img src="{{ file_path }}" alt="" />
+                <div class="specific-div-my">
+                  <div class="my-message-reactions">
+                    {% for reaction in reactions %}
+                      {% if reaction.id == message.id and reaction.file_path %}
+                        <div class="reaction-box">
+                          <img src="{{ reaction.file_path }}" alt="" />
+                          <span class="reaction-count">{{ reaction.reaction_count }}</span>
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
                 </div>
               </div>
             {% else %}
@@ -53,66 +62,71 @@
                     <input type="hidden" value="{{ channel.id }}" name="channel_id" />
                     <input type="hidden" value="{{ message.id }}" name="message_id" />
                     <button
-                      class="delete-message-btn"
+                      class="reaction-btn"
                       name="reaction_code"
                       value=" 1 "
                       >
-                      <ion-icon name="happy-outline"></ion-icon>
+                      <img src="../static/reaction_icons/good.png"/>
                     </button>
                   </form>
                   <form action="/reaction" method="POST">
                     <input type="hidden" value="{{ channel.id }}" name="channel_id" />
                     <input type="hidden" value="{{ message.id }}" name="message_id" />
                     <button
-                      class="delete-message-btn"
+                      class="reaction-btn"
                       name="reaction_code"
                       value=" 2 "
                       >
-                      <ion-icon name="happy-outline"></ion-icon>
+                      <img src="../static/reaction_icons/look.png"/>
                     </button>
                   </form>
                   <form action="/reaction" method="POST">
                     <input type="hidden" value="{{ channel.id }}" name="channel_id" />
                     <input type="hidden" value="{{ message.id }}" name="message_id" />
                     <button
-                      class="delete-message-btn"
+                      class="reaction-btn"
                       name="reaction_code"
                       value=" 3 "
                       >
-                      <ion-icon name="happy-outline"></ion-icon>
+                      <img src="../static/reaction_icons/love.png"/>
                     </button>
                   </form>
                   <form action="/reaction" method="POST">
                     <input type="hidden" value="{{ channel.id }}" name="channel_id" />
                     <input type="hidden" value="{{ message.id }}" name="message_id" />
                     <button
-                      class="delete-message-btn"
+                      class="reaction-btn"
                       name="reaction_code"
                       value=" 4 "
                       >
-                      <ion-icon name="happy-outline"></ion-icon>
+                      <img src="../static/reaction_icons/pray.png"/>
                     </button>
                   </form>
                   <form action="/reaction" method="POST">
                     <input type="hidden" value="{{ channel.id }}" name="channel_id" />
                     <input type="hidden" value="{{ message.id }}" name="message_id" />
                     <button
-                      class="delete-message-btn"
+                      class="reaction-btn"
                       name="reaction_code"
                       value=" 5 "
                       >
-                      <ion-icon name="happy-outline"></ion-icon>
+                      <img src="../static/reaction_icons/smile.png"/>
                     </button>
                   </form>
                 </div>
                 <p class="send-time">{{ message.send_at }}</p>
               </div>
-              <div>
-                {% for reaction in reactions|reverse %}
-                  {% if reaction.id == message.id %}
-                  <img id="other-message-reactions" src="{{ reaction.file_path }}" alt="" />
-                  {% endif %}
-                {% endfor %}
+              <div class="specific-div-other">
+                <div class="other-message-reactions">
+                  {% for reaction in reactions %}
+                    {% if reaction.id == message.id and reaction.file_path %}
+                      <div class="reaction-box">
+                        <img src="{{ reaction.file_path }}" alt="" />
+                        <span class="reaction-count">{{ reaction.reaction_count }}</span>
+                      </div>
+                    {% endif %}
+                  {% endfor %}
+                </div>
               </div>
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
リアクションされた時に、mid, uid, reaction_codeが同じだった場合はIntegrityErrorとなり、そのエラーは無視してdetail.htmlが再度レンダリングされる。

タイトルの件とともに、以下を修正。
- 自分のメッセージ側にリアクションが表示されていなかったこと。
- /messageでメッセージを送信後、リロードすると同じメッセージを再送信してしまうこと。
- /reactionについても上記/messageと同様。エンドポイントを/result/<channel_id>とすることで対応。
- リアクションされた回数を表示する。

変更が小分けではないこと、追い込み体制ということでお許しください。
リアクションのトリガーとなるボタンもリアクションの画像に一時的に設定したので、非常ににぎやかで見づらいチャット画面になっています。